### PR TITLE
Add a `kill` function for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
  "rand",
  "thiserror",
  "tokio",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ lazy_static = "1.4.0"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.20.0"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3.9", features = ["errhandlingapi"] }

--- a/src/process.rs
+++ b/src/process.rs
@@ -231,7 +231,7 @@ impl RunningProcess {
     }
 
     #[cfg(unix)]
-    pub fn kill(pid: u32) -> nix::Result<()> {
+    pub fn kill(pid: u32) -> Result<()> {
         use nix::{
             sys::signal::{self, Signal},
             unistd::Pid,
@@ -239,6 +239,7 @@ impl RunningProcess {
 
         let pid = Pid::from_raw(pid as i32);
         signal::kill(pid, Signal::SIGKILL)
+            .map_err(|err| Error::Zombie { pid, err })
     }
 
     #[cfg(windows)]

--- a/src/result.rs
+++ b/src/result.rs
@@ -23,12 +23,23 @@ pub enum Error {
     },
     /// When a process manager failed to kill hanged child process, there is a zombie process left hanging around.
     /// This error provides details, such as process id and an error, so user could handle cleaning manually.
+    #[cfg(unix)]
     #[error("Process with pid {pid} hanged and we were unable to kill it. Error: {err}", pid = .pid, err = .err)]
     Zombie {
         /// Process id of the hanged process.
         pid: u32,
         /// Error raised on attempt to terminate the hanged process.
         err: KillError,
+    },
+    /// When a process manager failed to kill hanged child process, there is a zombie process left hanging around.
+    /// This error provides details, such as process id and an error, so user could handle cleaning manually.
+    #[cfg(windows)]
+    #[error("Process with pid {pid} hanged and we were unable to kill it. Error: {err}", pid = .pid, err = .err)]
+    Zombie {
+        /// Process id of the hanged process.
+        pid: u32,
+        /// Error raised on attempt to terminate the hanged process.
+        err: winapi::shared::minwindef::DWORD,
     },
 }
 


### PR DESCRIPTION
Due to my limited knowledge of Windows' API, I had to do a bit of searching on how to properly implement it. I tested it with the example and the timeout worked without any errors.

I felt that it was better to copy `Error::Zombie` and add `#[cfg(windows)]` to that instead of the `err` member, easier to put `#[cfg(..)]` on match arms than on a struct member.